### PR TITLE
Get rid of Object.assign({})

### DIFF
--- a/src/actions/MIDIActions.js
+++ b/src/actions/MIDIActions.js
@@ -1,6 +1,6 @@
 import Soundfont from 'soundfont-player';
 import { MIDIInstruments, SOUNDS_PATH, SOUNDS_FILETYPE, SOUNDS_FILE_EXTENSION } from '../constants/MIDIInstruments';
-import { MIDIMessages } from '../constants/MIDIMessages';
+import MIDIMessages from '../constants/MIDIMessages';
 import { TimeUtils } from '../utils/TimeUtils';
 import { InstrumentUtils } from '../utils/InstrumentUtils';
 

--- a/src/constants/MIDIMessages.js
+++ b/src/constants/MIDIMessages.js
@@ -1,4 +1,4 @@
-export const MIDIMessages = Object.freeze({
+export default Object.freeze({
   SEQUENCE_NUMBER: 'sequenceNumber',
   TEXT: 'text',
   TRACK_NAME: 'trackName',

--- a/src/reducers/FileReducer.js
+++ b/src/reducers/FileReducer.js
@@ -6,10 +6,11 @@ const initialState = {
 
 export default function MIDIFileReducer(state=initialState, action) {
   switch (action.type) {
-    case FileAction.LOAD_FILE:
-      return Object.assign({}, state, {
+      case FileAction.LOAD_FILE:
+      return {
+        ...state,
         song: action.payload.song
-      });
+      };
     default:
       return state;
     }

--- a/src/reducers/FileReducer.js
+++ b/src/reducers/FileReducer.js
@@ -4,14 +4,14 @@ const initialState = {
   song: null
 };
 
-export default function MIDIFileReducer(state=initialState, action) {
+export default function MIDIFileReducer(state = initialState, action) {
   switch (action.type) {
-      case FileAction.LOAD_FILE:
+    case FileAction.LOAD_FILE:
       return {
         ...state,
         song: action.payload.song
       };
     default:
       return state;
-    }
+  }
 }

--- a/src/reducers/MIDIReducer.js
+++ b/src/reducers/MIDIReducer.js
@@ -9,151 +9,175 @@ const initialState = {
 
 export default function MIDIEventsReducer(state=initialState, action) {
   switch (action.type) {
-    case MIDIMessages.SEQUENCE_NUMBER:
-      return Object.assign({}, state, {
+      case MIDIMessages.SEQUENCE_NUMBER:
+      return {
+        ...state,
         tracks: action.payload.tracks,
         trackIndex: action.payload.trackIndex,
         midiMessage: action.payload.midiMessage
-      });
+      };
     case MIDIMessages.TEXT:
-      return Object.assign({}, state, {
+      return {
+        ...state,
         tracks: action.payload.tracks,
         trackIndex: action.payload.trackIndex,
         midiMessage: action.payload.midiMessage
-      });
+      };
     case MIDIMessages.TRACK_NAME:
-      return Object.assign({}, state, {
+      return {
+        ...state,
         tracks: action.payload.tracks,
         trackIndex: action.payload.trackIndex,
         midiMessage: action.payload.midiMessage
-      });
+      };
     case MIDIMessages.PROGRAM_CHANGE:
-      return Object.assign({}, state, {
+      return {
+        ...state,
         instruments: action.payload.instruments,
         tracks: action.payload.tracks,
         trackIndex: action.payload.trackIndex,
         midiMessage: action.payload.midiMessage
-      });
+      };
     case MIDIMessages.INSTRUMENT_NAME:
-      return Object.assign({}, state, {
+      return {
+        ...state,
         tracks: action.payload.tracks,
         trackIndex: action.payload.trackIndex,
         midiMessage: action.payload.midiMessage
-      });
+      };
     case MIDIMessages.LYRICS:
-      return Object.assign({}, state, {
+      return {
+        ...state,
         tracks: action.payload.tracks,
         trackIndex: action.payload.trackIndex,
         midiMessage: action.payload.midiMessage
-      });
+      };
     case MIDIMessages.MARKER:
-      return Object.assign({}, state, {
+      return {
+        ...state,
         tracks: action.payload.tracks,
         trackIndex: action.payload.trackIndex,
         midiMessage: action.payload.midiMessage
-      });
+      };
     case MIDIMessages.CUE_POINT:
-      return Object.assign({}, state, {
+      return {
+        ...state,
         tracks: action.payload.tracks,
         trackIndex: action.payload.trackIndex,
         midiMessage: action.payload.midiMessage
-      });
+      };
     case MIDIMessages.MIDI_CHANNEL_PREFIX:
-      return Object.assign({}, state, {
+      return {
+        ...state,
         tracks: action.payload.tracks,
         trackIndex: action.payload.trackIndex,
         midiMessage: action.payload.midiMessage
-      });
+      };
     case MIDIMessages.END_OF_TRACK:
-      return Object.assign({}, state, {
+      return {
+        ...state,
         tracks: action.payload.tracks,
         trackIndex: action.payload.trackIndex,
         midiMessage: action.payload.midiMessage
-      });
+      };
     case MIDIMessages.SET_TEMPO:
-      return Object.assign({}, state, {
+      return {
+        ...state,
         tracks: action.payload.tracks,
         trackIndex: action.payload.trackIndex,
         midiMessage: action.payload.midiMessage
-      });
+      };
     case MIDIMessages.SMPTE_OFFSET:
-      return Object.assign({}, state, {
+      return {
+        ...state,
         tracks: action.payload.tracks,
         trackIndex: action.payload.trackIndex,
         midiMessage: action.payload.midiMessage
-      });
+      };
     case MIDIMessages.TIME_SIGNATURE:
-      return Object.assign({}, state, {
+      return {
+        ...state,
         tracks: action.payload.tracks,
         trackIndex: action.payload.trackIndex,
         midiMessage: action.payload.midiMessage
-      });
+      };
     case MIDIMessages.KEY_SIGNATURE:
-      return Object.assign({}, state, {
+      return {
+        ...state,
         tracks: action.payload.tracks,
         trackIndex: action.payload.trackIndex,
         midiMessage: action.payload.midiMessage
-      });
+      };
     case MIDIMessages.SEQUENCER_SPECIFIC:
-      return Object.assign({}, state, {
+      return {
+        ...state,
         tracks: action.payload.tracks,
         trackIndex: action.payload.trackIndex,
         midiMessage: action.payload.midiMessage
-      });
+      };
     case MIDIMessages.SYS_EX:
-      return Object.assign({}, state, {
+      return {
+        ...state,
         tracks: action.payload.tracks,
         trackIndex: action.payload.trackIndex,
         midiMessage: action.payload.midiMessage
-      });
+      };
     case MIDIMessages.DIVIDED_SYS_EX:
-      return Object.assign({}, state, {
+      return {
+        ...state,
         tracks: action.payload.tracks,
         trackIndex: action.payload.trackIndex,
         midiMessage: action.payload.midiMessage
-      });
+      };
     case MIDIMessages.LAST:
-      return Object.assign({}, state, {
+      return {
+        ...state,
         tracks: action.payload.tracks,
         trackIndex: action.payload.trackIndex,
         midiMessage: action.payload.midiMessage
-      });
+      };
     case MIDIMessages.NOTE_OFF:
-      return Object.assign({}, state, {
+      return {
+        ...state,
         tracks: action.payload.tracks,
         trackIndex: action.payload.trackIndex,
         midiMessage: action.payload.midiMessage
-      });
+      };
     case MIDIMessages.NOTE_ON:
-      return Object.assign({}, state, {
+      return {
+        ...state,
         tracks: action.payload.tracks,
         trackIndex: action.payload.trackIndex,
         midiMessage: action.payload.midiMessage
-      });
+      };
     case MIDIMessages.NOTE_AFTER_TOUCH:
-      return Object.assign({}, state, {
+      return {
+        ...state,
         tracks: action.payload.tracks,
         trackIndex: action.payload.trackIndex,
         midiMessage: action.payload.midiMessage
-      });
+      };
     case MIDIMessages.CHANNEL_AFTER_TOUCH:
-      return Object.assign({}, state, {
+      return {
+        ...state,
         tracks: action.payload.tracks,
         trackIndex: action.payload.trackIndex,
         midiMessage: action.payload.midiMessage
-      });
+      };
     case MIDIMessages.PITCH_BEND:
-      return Object.assign({}, state, {
+      return {
+        ...state,
         tracks: action.payload.tracks,
         trackIndex: action.payload.trackIndex,
         midiMessage: action.payload.midiMessage
-      });
+      };
     case MIDIMessages.UNKNOWN:
-      return Object.assign({}, state, {
+      return {
+        ...state,
         tracks: action.payload.tracks,
         trackIndex: action.payload.trackIndex,
         midiMessage: action.payload.midiMessage
-      });
+      };
     default:
       return state;
   }

--- a/src/reducers/MIDIReducer.js
+++ b/src/reducers/MIDIReducer.js
@@ -1,4 +1,4 @@
-import { MIDIMessages } from '../constants/MIDIMessages';
+import MIDIMessages from '../constants/MIDIMessages';
 import { DEFAULT_TEMPO_BPM } from '../constants/MIDIInstruments';
 
 const initialState = {
@@ -7,170 +7,38 @@ const initialState = {
   tempo: DEFAULT_TEMPO_BPM
 };
 
-export default function MIDIEventsReducer(state=initialState, action) {
+export default function MIDIEventsReducer(state = initialState, action) {
   switch (action.type) {
-      case MIDIMessages.SEQUENCE_NUMBER:
-      return {
-        ...state,
-        tracks: action.payload.tracks,
-        trackIndex: action.payload.trackIndex,
-        midiMessage: action.payload.midiMessage
-      };
-    case MIDIMessages.TEXT:
-      return {
-        ...state,
-        tracks: action.payload.tracks,
-        trackIndex: action.payload.trackIndex,
-        midiMessage: action.payload.midiMessage
-      };
-    case MIDIMessages.TRACK_NAME:
-      return {
-        ...state,
-        tracks: action.payload.tracks,
-        trackIndex: action.payload.trackIndex,
-        midiMessage: action.payload.midiMessage
-      };
     case MIDIMessages.PROGRAM_CHANGE:
       return {
         ...state,
-        instruments: action.payload.instruments,
         tracks: action.payload.tracks,
         trackIndex: action.payload.trackIndex,
-        midiMessage: action.payload.midiMessage
+        midiMessage: action.payload.midiMessage,
+        instruments: action.payload.instruments
       };
+    case MIDIMessages.SEQUENCE_NUMBER:
+    case MIDIMessages.TEXT:
+    case MIDIMessages.TRACK_NAME:
     case MIDIMessages.INSTRUMENT_NAME:
-      return {
-        ...state,
-        tracks: action.payload.tracks,
-        trackIndex: action.payload.trackIndex,
-        midiMessage: action.payload.midiMessage
-      };
     case MIDIMessages.LYRICS:
-      return {
-        ...state,
-        tracks: action.payload.tracks,
-        trackIndex: action.payload.trackIndex,
-        midiMessage: action.payload.midiMessage
-      };
     case MIDIMessages.MARKER:
-      return {
-        ...state,
-        tracks: action.payload.tracks,
-        trackIndex: action.payload.trackIndex,
-        midiMessage: action.payload.midiMessage
-      };
     case MIDIMessages.CUE_POINT:
-      return {
-        ...state,
-        tracks: action.payload.tracks,
-        trackIndex: action.payload.trackIndex,
-        midiMessage: action.payload.midiMessage
-      };
     case MIDIMessages.MIDI_CHANNEL_PREFIX:
-      return {
-        ...state,
-        tracks: action.payload.tracks,
-        trackIndex: action.payload.trackIndex,
-        midiMessage: action.payload.midiMessage
-      };
     case MIDIMessages.END_OF_TRACK:
-      return {
-        ...state,
-        tracks: action.payload.tracks,
-        trackIndex: action.payload.trackIndex,
-        midiMessage: action.payload.midiMessage
-      };
     case MIDIMessages.SET_TEMPO:
-      return {
-        ...state,
-        tracks: action.payload.tracks,
-        trackIndex: action.payload.trackIndex,
-        midiMessage: action.payload.midiMessage
-      };
     case MIDIMessages.SMPTE_OFFSET:
-      return {
-        ...state,
-        tracks: action.payload.tracks,
-        trackIndex: action.payload.trackIndex,
-        midiMessage: action.payload.midiMessage
-      };
     case MIDIMessages.TIME_SIGNATURE:
-      return {
-        ...state,
-        tracks: action.payload.tracks,
-        trackIndex: action.payload.trackIndex,
-        midiMessage: action.payload.midiMessage
-      };
     case MIDIMessages.KEY_SIGNATURE:
-      return {
-        ...state,
-        tracks: action.payload.tracks,
-        trackIndex: action.payload.trackIndex,
-        midiMessage: action.payload.midiMessage
-      };
     case MIDIMessages.SEQUENCER_SPECIFIC:
-      return {
-        ...state,
-        tracks: action.payload.tracks,
-        trackIndex: action.payload.trackIndex,
-        midiMessage: action.payload.midiMessage
-      };
     case MIDIMessages.SYS_EX:
-      return {
-        ...state,
-        tracks: action.payload.tracks,
-        trackIndex: action.payload.trackIndex,
-        midiMessage: action.payload.midiMessage
-      };
     case MIDIMessages.DIVIDED_SYS_EX:
-      return {
-        ...state,
-        tracks: action.payload.tracks,
-        trackIndex: action.payload.trackIndex,
-        midiMessage: action.payload.midiMessage
-      };
     case MIDIMessages.LAST:
-      return {
-        ...state,
-        tracks: action.payload.tracks,
-        trackIndex: action.payload.trackIndex,
-        midiMessage: action.payload.midiMessage
-      };
     case MIDIMessages.NOTE_OFF:
-      return {
-        ...state,
-        tracks: action.payload.tracks,
-        trackIndex: action.payload.trackIndex,
-        midiMessage: action.payload.midiMessage
-      };
     case MIDIMessages.NOTE_ON:
-      return {
-        ...state,
-        tracks: action.payload.tracks,
-        trackIndex: action.payload.trackIndex,
-        midiMessage: action.payload.midiMessage
-      };
     case MIDIMessages.NOTE_AFTER_TOUCH:
-      return {
-        ...state,
-        tracks: action.payload.tracks,
-        trackIndex: action.payload.trackIndex,
-        midiMessage: action.payload.midiMessage
-      };
     case MIDIMessages.CHANNEL_AFTER_TOUCH:
-      return {
-        ...state,
-        tracks: action.payload.tracks,
-        trackIndex: action.payload.trackIndex,
-        midiMessage: action.payload.midiMessage
-      };
     case MIDIMessages.PITCH_BEND:
-      return {
-        ...state,
-        tracks: action.payload.tracks,
-        trackIndex: action.payload.trackIndex,
-        midiMessage: action.payload.midiMessage
-      };
     case MIDIMessages.UNKNOWN:
       return {
         ...state,

--- a/src/reducers/PlayerReducer.js
+++ b/src/reducers/PlayerReducer.js
@@ -7,9 +7,9 @@ const initialState = {
   instruments: null
 };
 
-export default function MIDIPlayerReducer(state=initialState, action) {
+export default function MIDIPlayerReducer(state = initialState, action) {
   switch (action.type) {
-      case Player.PLAY:
+    case Player.PLAY:
       return {
         ...state,
         instruments: action.payload.instruments,
@@ -19,5 +19,5 @@ export default function MIDIPlayerReducer(state=initialState, action) {
       };
     default:
       return state;
-    }
+  }
 }

--- a/src/reducers/PlayerReducer.js
+++ b/src/reducers/PlayerReducer.js
@@ -9,13 +9,14 @@ const initialState = {
 
 export default function MIDIPlayerReducer(state=initialState, action) {
   switch (action.type) {
-    case Player.PLAY:
-      return Object.assign({}, state, {
+      case Player.PLAY:
+      return {
+        ...state,
         instruments: action.payload.instruments,
         tracks: action.payload.tracks,
         isPlaying: true,
         ticksPerBeat: action.payload.ticksPerBeat
-      });
+      };
     default:
       return state;
     }

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,13 +1,13 @@
 import { combineReducers } from 'redux';
 
-import MIDIReducer from '../reducers/MIDIReducer';
-import PlayerReducer from '../reducers/PlayerReducer';
-import FileReducer from '../reducers/FileReducer';
+import midi from '../reducers/MIDIReducer';
+import player from '../reducers/PlayerReducer';
+import file from '../reducers/FileReducer';
 
 const rootReducer = combineReducers({
-  midi:   MIDIReducer,
-  player: PlayerReducer,
-  file:   FileReducer
+  midi,
+  player,
+  file
 });
 
 export default rootReducer;


### PR DESCRIPTION
The project looks awesome! This is just a minor change. 😉 

Since you are using Babel's `stage-0`, you have support already for the [**object-spread-operator**](http://babeljs.io/docs/plugins/transform-object-rest-spread/) (`stage-3`), which allows you to get rid of the `Object.assign({}, ...)` code.

I think it's a nice improvement that would make @gaearon happy! 😜 